### PR TITLE
Return csrf token when calling login function

### DIFF
--- a/src/node-backend/adapters/wiki-adapter.js
+++ b/src/node-backend/adapters/wiki-adapter.js
@@ -26,7 +26,7 @@ export async function login(credentials) {
 }
 
 export async function getEditToken() {
-    return wiki.getCsrfToken();
+    return getTokenOfType("csrf");
 }
 
 export async function getAccountCreationToken() {

--- a/src/node-backend/controller/accounts-controller.js
+++ b/src/node-backend/controller/accounts-controller.js
@@ -74,6 +74,7 @@ async function login(credentials = new Credentials()) {
             throw Error("Error while trying to log in: " + e);
         }
     });
+    loginResult["token"] = wikiAdapter.getEditToken();
     return loginResult;
 }
 

--- a/src/node-backend/controller/accounts-controller.js
+++ b/src/node-backend/controller/accounts-controller.js
@@ -74,7 +74,7 @@ async function login(credentials = new Credentials()) {
             throw Error("Error while trying to log in: " + e);
         }
     });
-    loginResult["token"] = wikiAdapter.getEditToken();
+    loginResult[loginAction]["token"] = await wikiAdapter.getEditToken();
     return loginResult;
 }
 


### PR DESCRIPTION
Closes #95 

@quaverous2 calling the student login (and eventually the teacher's login too) returns the csrf token now.

```{
    "clientlogin": {
        "status": "PASS",
        "username": "username",
        "token": "randomTokenString+\\"
    }